### PR TITLE
Fix unresolved link reference

### DIFF
--- a/help/cloud-guide/store/multiple-sites.md
+++ b/help/cloud-guide/store/multiple-sites.md
@@ -333,5 +333,5 @@ Adobe recommends fully testing in the Staging environment before pushing to the 
 
 <!-- link definitions -->
 
-[addstorecode]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/multi-sites/ms-admin.html#step-6%3A-add-the-store-code-to-the-base-url
+[addstorecode]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/multi-sites/ms-admin.html
 [config-multiweb]: https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/multi-sites/ms-overview.html


### PR DESCRIPTION
## Purpose of this pull request

Fix unresolved link by removing the anchor reference in the [storecode] link definition.

![2023-02-08_16-31-53](https://user-images.githubusercontent.com/6391769/217667270-99102958-a5c2-44f8-b760-51cc1ca5ab79.png)


## Affected pages

https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/configure-store/multiple-sites.html
