### PR TITLE
Fix link to Fastly latest version info

### DIFF
--- a/help/cloud-guide/cdn/fastly-configuration.md
+++ b/help/cloud-guide/cdn/fastly-configuration.md
@@ -271,7 +271,7 @@ If the headers do not have the correct values, see [Resolve errors found in the 
 ## Upgrade the Fastly module
 
 Fastly updates the Fastly CDN for Magento 2 module to resolve issues, increase performance, and provide new features.
-We recommend that you update the Fastly module in your Staging and Production environments to the [latest version](https://github.com/fastly/fastly-magento2/releases).
+We recommend that you update the Fastly module in your Staging and Production environments to the [latest version](https://github.com/fastly/fastly-magento2/blob/master/VERSION).
 
 After you update the module, you must upload the VCL code to apply the changes to the Fastly service configuration.
 


### PR DESCRIPTION
Fastly module doesn't use release tags feature in GitHub. Latest module version is available at https://github.com/fastly/fastly-magento2/blob/master/VERSION

## Purpose of this pull request

This pull request (PR) ...

## Affected pages

<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Commerce code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED.
If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add the link here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.

`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/AdobeDocs/commerce-operations.en/blob/main/contributing.md) for more information.
-->
