### PR TITLE
Update php-extensions-cloud.md

### DIFF
--- a/help/_includes/templated/php-extensions-cloud.md
+++ b/help/_includes/templated/php-extensions-cloud.md
@@ -27,7 +27,6 @@
                 libxml<br>
                 mysqli<br>
                 opcache<br>
-                openswoole<br>
                 pcntl<br>
                 pdo_mysql<br>
                 Reflection<br>
@@ -35,6 +34,7 @@
                 sockets<br>
                 SPL<br>
                 standard<br>
+                swoole<br>
                 sysvmsg<br>
                 sysvsem<br>
                 sysvshm<br>


### PR DESCRIPTION
## Purpose of this pull request

Adobe Commerce Cloud uses PHP extension swoole, not openswoole

https://experienceleague.adobe.com/en/docs/commerce-operations/performance-best-practices/concepts/application-server

https://developer.adobe.com/commerce/php/development/components/app-server/

## Affected pages

https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/configure/app/php-settings
