### PR TITLE
Fix paths indentation in redirects

### DIFF
--- a/help/cloud-guide/routes/redirects.md
+++ b/help/cloud-guide/routes/redirects.md
@@ -76,7 +76,7 @@ Use the following format to configure redirect requests based on a regular expre
 http://{default}/:
     type: upstream
     redirects:
-    paths:
+      paths:
         "/regexp/(.*)/match": { to: "http://example.com/$1", regexp: true }
 ```
 
@@ -90,7 +90,7 @@ Use the following format to configure redirect requests for paths that begin wit
 http://{default}/:
     type: upstream
     redirects:
-    paths:
+      paths:
         "/from": { to: "https://{default}/to", prefix: true }
 ```
 
@@ -110,7 +110,7 @@ Use the following format to configure redirect requests which append the path su
 http://{default}/:
     type: upstream
     redirects:
-    paths: "/from": { to: "https://{default}/to", append_suffix: false }
+      paths: "/from": { to: "https://{default}/to", append_suffix: false }
 ```
 
 This configuration works as follows:
@@ -128,7 +128,7 @@ http://{default}/:
     type: upstream
     redirects:
     expires: 1d
-    paths:
+      paths:
         "/from": { to: "https://example.com/" }
         "/here": { to: "https://example.com/there", expires: "2w" }
 ```


### PR DESCRIPTION

## Purpose of this pull request

This pull request (PR) fixes indents around the paths options in examples of the redirects key.


## Affected pages

<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Commerce code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED.
If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add the link here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.

`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.

See Contribution guidelines (https://github.com/AdobeDocs/commerce-operations.en/blob/main/contributing.md) for more information.
-->
